### PR TITLE
Update normalize.js

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -62,14 +62,15 @@ var table = {
     "q": "cw",
     "qu": "cw",
     "p": "p",
-    "ph": "f",
+ //hh   "ph": "f",  
     "b": "b",
     "bh": "v",
     "â": "á",
     "ê": "é",
     "î": "í",
     "ô": "ó",
-    "û": "ú"
+    "û": "ú",
+    "'": "/"
 };
 
 // This generates a data structure that can be walked by a parser, where each
@@ -103,4 +104,3 @@ var simplify = makeParserFromTrie(
         };
     }
 );
-


### PR DESCRIPTION
Revert treatment of 'ph' so it can be dealt with separately in general-use mode.  Add mapping of apostrophe key to forward slash to allow non-technical users to be able to type an apostrophe or forward slash on the keyboard and have it render an 'apostrophe like' character and not error out.