### PR TITLE
Add bindings for English Y tehta above tengwa

### DIFF
--- a/alphabet.js
+++ b/alphabet.js
@@ -17,7 +17,7 @@ exports.tengwar = [
 exports.tehtarAbove = [
     "a", "e", "i", "o", "u",
     "á", "é", "í", "ó", "ú",
-    "w"
+    "w", "y-above",
 ];
 
 exports.tehtarBelow = [

--- a/dan-smith.js
+++ b/dan-smith.js
@@ -119,6 +119,7 @@ exports.tehtar = {
     ],
     "w": "èéêë", // TODO custom hooks for tengwar parmaite from the alternate font
     "y": "ÌÍÎÏ´",
+    "y-above": "ØÙÚÛ",
     "o-below": [
         "ä",
         "å",

--- a/tengwar-parmaite.js
+++ b/tengwar-parmaite.js
@@ -120,6 +120,7 @@ var positions = exports.positions = {
         "y": 1,
         "í": 2,
         "i-below": 1,
+        "y-above": 2,
         "others": 3
     },
     "anna": {
@@ -130,6 +131,7 @@ var positions = exports.positions = {
     "wilya": {
         "i": 2,
         "í": 2,
+        "y-above": 2,
         "others": 1
     },
 
@@ -153,6 +155,7 @@ var positions = exports.positions = {
         "w": 1,
         "í": 2,
         "y": 3,
+        "y-above": 2,
         "o-below": null,
         "i-below": 3,
         "others": 0
@@ -179,6 +182,7 @@ var positions = exports.positions = {
         "y": 2,
         "o-below": 2,
         "i-below": 2,
+        "y-above": 2,
         "others": null
     },
     "silme-nuquerna": {

--- a/tengwar-parmaite.js
+++ b/tengwar-parmaite.js
@@ -200,6 +200,7 @@ var positions = exports.positions = {
         "y": null,
         "o-below": null,
         "i-below": null,
+        "y-above": null,
         "others": 1
     },
 

--- a/tengwar-parmaite.js
+++ b/tengwar-parmaite.js
@@ -182,7 +182,6 @@ var positions = exports.positions = {
         "y": 2,
         "o-below": 2,
         "i-below": 2,
-        "y-above": 2,
         "others": null
     },
     "silme-nuquerna": {
@@ -200,7 +199,6 @@ var positions = exports.positions = {
         "y": null,
         "o-below": null,
         "i-below": null,
-        "y-above": null,
         "others": 1
     },
 


### PR DESCRIPTION
This includes the relevant changes to show the tehta above every tengwa
in both fonts in the proofs, and the necessary kerning adjustments for
each font.

Fixes #28