### PR TITLE
Address backtick inconsistencies

### DIFF
--- a/public/modes.html
+++ b/public/modes.html
@@ -640,11 +640,11 @@
                 <td>
                     <td><span class="general-use-font" data-tengwar="s s`
                         z z`
-                        x x`" data-mode="general-use"></span>
+                        x ks ks`" data-mode="general-use"></span>
                     <td>
                         <code>s</code>, <code>s`</code><br>
                         <code>z</code>, <code>z`</code><br>
-                        <code>x</code>, <code>x`</code>
+                        <code>x</code>, <code>ks</code>, <code>ks`</code>
                     </td>
             </tr>
 

--- a/public/sample.html
+++ b/public/sample.html
@@ -190,7 +190,7 @@
 
         <p>Allys: <span class="transcribe">Allys</span>. Not elvish. Lots of potential mis-interactions between the double-L, the Y-diacritic, and following-S.</p>
 
-        <p>Hobbits'': <span class="transcribe">Hobbits''</span>. Illustrates the use of a straight apostrophe to use alternate S-hooks.</p>
+        <p>Hobbits``: <span class="transcribe">Hobbits``</span>. Illustrates the use of a straight apostrophe to use alternate S-hooks.</p>
 
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
         <script src="sample.js"></script>


### PR DESCRIPTION
In prior changes, we revised the tick notation to be a backtick notation
and also eliminate the phoneme input normalizer.
In the process, X became distinguishable from KS and it did not make
sense any longer for the X` notation to degerate to KS, but remained
sensible to have KS` notation to explicitly opt-out of consolidation
into the special calma S-hook.

This change corrects the documentation and also catches some ticks
previously missed.