### PR TITLE
Cover more cases for silent final E

### DIFF
--- a/general-use.js
+++ b/general-use.js
@@ -823,13 +823,24 @@ function parseTengwa(callback, options, tehta, tehtaFrom) {
                 tehtaFrom
             );
         } else if (character === "`" && options.language === "english" && tehta === "e") {
-            // final e/ in english should be equivalent to diaresis
-            return callback(
-                makeColumn("short-carrier", {from: ""})
-                    .addAbove("e", {from: "e"})
-            );
+            return function (character2) {
+                if (character2 === "") {
+                    // final e` in english should be equivalent to diaresis.
+                    // tehta deliberately consumed in this case, not passed forward.
+                    return callback(
+                        makeColumn("short-carrier", {from: ""})
+                            .addAbove("e", {from: "e"})
+                    );
+                } else {
+                    // tehta deliberately consumed in this case, not passed forward.
+                    return callback(
+                        makeColumn("short-carrier", {from: ""})
+                            .addBelow("i-below", {from: "e", silent: true})
+                    )(character)(character2);
+                }
+            };
         } else if (character === "" && options.language === "english" && tehta === "e") {
-            // tehta deliberately consumed in this one case, not passed forward
+            // tehta deliberately consumed in this case, not passed forward.
             return callback(
                 makeColumn("short-carrier", {from: ""})
                     .addBelow("i-below", {from: "e", silent: true})

--- a/test/general-use.js
+++ b/test/general-use.js
@@ -53,6 +53,7 @@ module.exports = {
             // english (appropriate mode) (sorted)
             "Alyssa": "lambe:a;silme-nuquerna:y-english,tilde-below;short-carrier:a",
             "Jack": "anga;quesse:a,tilde-below",
+            "axe": "quesse:a,s;short-carrier:i-below",
             "cake": "quesse;quesse:a,i-below",
             "cakes": "quesse;quesse:a;silme-nuquerna:e",
             "cats.": "quesse;tinco:a,s-final;full-stop", // regression
@@ -76,7 +77,11 @@ module.exports = {
             "yes": "anna;silme-nuquerna:e",
 
             // for code coverage
-            "ie": "yanta:i",
+            "e": "short-carrier:i-below", // final e is silent
+            "e`": "short-carrier:e", // effectively a diaeresis
+            "en": "numen:e", // medial e is voiced
+            "ie": "yanta:i", // ie treated as diphthong regardless of pronunciation
+            "ne": "numen;short-carrier:i-below", // tehta carried forward, still silent when final
             "oe": "yanta:o",
             "x": "quesse:s",
             "y": "anna",


### PR DESCRIPTION
Previously, English "axe" in the mode for general use was rendered as voiced.  This change addresses the case and introduces a alternate notation to explicitly mark as voiced, in addition to daieresis.