### PR TITLE
Fix rendering of nwalme in the classical mode

### DIFF
--- a/classical.js
+++ b/classical.js
@@ -161,6 +161,8 @@ function parseTengwa(callback, options, previous) {
                             return callback([makeColumn("unque", {from: "nq"})])(character3);
                         }
                     };
+                } else if (character2 === "w" && previous == null) {
+                    return callback([makeColumn("nwalme", {from: "nw"})]);
                 } else {
                     return callback([makeColumn("numen", {from: "n"})])(character2);
                 }

--- a/test/classical.js
+++ b/test/classical.js
@@ -1,4 +1,5 @@
 module.exports = {
+    "eldarinwa": "short-carrier:e;alda:a;romen:i;numen;wilya:a", // suggested by arnog
     "hlóce": "halla;lambe:ó;calma:e", // attested
     "hríve": "halla;romen;long-carrier:i;vala:e", // attested
     "hyarmen": "hyarmen:a,y-quenya;ore;malta:e;numen",
@@ -6,6 +7,7 @@ module.exports = {
     "moria": "malta:o;romen:i;short-carrier:a",
     "namaarië": "numen:a;malta;long-carrier:a;romen:i;short-carrier:e",
     "namárië": "numen:a;malta;long-carrier:a;romen:i;short-carrier:e",
+    "nwalme": "nwalme:a;lambe;malta:e",
     "quenya": "quesse:e;numen:a,y-quenya",
     "silme": "silme-nuquerna:i;lambe;malta:e",
     "syi": "silme:y-quenya;short-carrier:i", //*
@@ -13,6 +15,7 @@ module.exports = {
     "tyelpe": "tinco:e,y-quenya;lambe;parma:e",
     "unque": "short-carrier:u;unque:e",
     "vanwa": "vala:a;numen;wilya:a",
+    "yonwa": "anna:o,y-quenya;numen;wilya:a", // suggested by arnog
     "yuldar": "anna:u,y-quenya;alda:a;ore",
 
     // long vowels


### PR DESCRIPTION
The name of the tengwa nwalme is presumably spelled using the eponymous tengwa, implying a pronunciation consistent with ñw but not ñgw (ungwe).

Using nwalme for all occurrences of nw breaks the test case for vanwa, which is allegedly rendered as numen followed by wilya. I suspect that the test case in error, but could use a second opinion.

This change, as written, assumes the test case is correct and uses nwalme only in the initial position of a word.